### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ For full usage examples, check out the [Objective-C](https://github.com/moltin/i
 ## Installation
 There are two ways to install the Moltin SDK in your project:
 
-- Using Cocoapods (recommended)
+- Using CocoaPods (recommended)
 - Manual installation by copying all of the files in the Moltin directory into your project, and adding them to your target
 
 ### Installation with CocoaPods


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
