### PR TITLE
Parse API errors correctly

### DIFF
--- a/Sources/SDK/Utils/DataSerializer.swift
+++ b/Sources/SDK/Utils/DataSerializer.swift
@@ -9,6 +9,7 @@ import Foundation
 
 protocol DataSerializer {
     func serialize(_ data: Any) throws -> Data
+    func deserialize(_ data: Data?) throws -> Any
 }
 
 class MoltinDataSerializer: DataSerializer {
@@ -16,5 +17,10 @@ class MoltinDataSerializer: DataSerializer {
     func serialize(_ data: Any) throws -> Data {
         let payload: [String: Any] = ["data": data]
         return try JSONSerialization.data(withJSONObject: payload, options: [])
+    }
+
+    func deserialize(_ data: Data?) throws -> Any {
+        guard let data = data else { return [:] }
+        return try JSONSerialization.jsonObject(with: data, options: [])
     }
 }

--- a/Sources/SDK/Utils/HTTP.swift
+++ b/Sources/SDK/Utils/HTTP.swift
@@ -32,8 +32,23 @@ class MoltinHTTP {
         }
 
         self.session.dataTask(with: urlRequest) { (data, response, error) in
-            completionHandler(data, response, error)
-        }.resume()
+            guard let statusCode = (response as? HTTPURLResponse)?.statusCode else {
+                completionHandler(data, response, error)
+                return
+            }
+
+            if 200...299 ~= statusCode {
+                completionHandler(data, response, error)
+            } else {
+                let errorData = try? self.dataSerializer.deserialize(data)
+                let errorObject = NSError(domain: "com.moltin", code: statusCode, userInfo: [
+                    "error": errorData ?? [:]
+                    ])
+
+                completionHandler(data, response, errorObject)
+            }
+
+            }.resume()
     }
 
     func buildURLRequest(withConfiguration configuration: MoltinConfig,

--- a/Sources/SDK/Utils/HTTP.swift
+++ b/Sources/SDK/Utils/HTTP.swift
@@ -41,9 +41,7 @@ class MoltinHTTP {
                 completionHandler(data, response, error)
             } else {
                 let errorData = try? self.dataSerializer.deserialize(data)
-                let errorObject = NSError(domain: "com.moltin", code: statusCode, userInfo: [
-                    "error": errorData ?? [:]
-                    ])
+                let errorObject = NSError(domain: "com.moltin", code: statusCode, userInfo: errorData as? [String: Any])
 
                 completionHandler(data, response, errorObject)
             }

--- a/Tests/moltin iOS Tests/HTTPMock.swift
+++ b/Tests/moltin iOS Tests/HTTPMock.swift
@@ -45,6 +45,9 @@ class MockedMoltinHTTP: MoltinHTTP {
 }
 
 class MockedMoltinDataSerializer: DataSerializer {
+    func deserialize(_ data: Data?) throws -> Any {
+        throw MoltinError.couldNotParseData(underlyingError: nil)
+    }
 
     func serialize(_ data: Any) throws -> Data {
         throw MoltinError.couldNotSetData


### PR DESCRIPTION
## Status
* ✅ Ready
## Type
* ### Fix
  Fixes an issue
## Description
Resolves an issue where API errors were not being correctly parsed and passed back to the user, instead they were silently succeeding, but returned errors attempting to parse into their successful objects. 
## Issues
Fixes https://forum.moltin.com/t/cart-addproduct-returning-error/718/2
