### PR TITLE
Fixed issue where a URL encoded space may be placed in the query param

### DIFF
--- a/Sources/SDK/Utils/Query.swift
+++ b/Sources/SDK/Utils/Query.swift
@@ -90,7 +90,7 @@ open class MoltinQuery {
 
         if self.withFilter.count > 0 {
             let filterString = self.withFilter.map { (op, key, value) -> String in
-                return "\(op.rawValue)(\(key), \(value))"
+                return "\(op.rawValue)(\(key),\(value))"
             }.joined(separator: ":")
             queryParams.append(URLQueryItem(name: "filter", value: filterString))
         }

--- a/Tests/moltin iOS Tests/MoltinTests.swift
+++ b/Tests/moltin iOS Tests/MoltinTests.swift
@@ -171,7 +171,7 @@ class MoltinTests: XCTestCase {
         let components = URLComponents(url: urlRequest!.url!, resolvingAgainstBaseURL: false)
         XCTAssertNotNil(components)
         XCTAssertNotNil(components?.query)
-        XCTAssert(components!.query! == "filter=eq(test, hello)")
+        XCTAssert(components!.query! == "filter=eq(test,hello)")
     }
 
     func testRequestHandlesMultipleFilter() {
@@ -190,7 +190,7 @@ class MoltinTests: XCTestCase {
         let components = URLComponents(url: urlRequest!.url!, resolvingAgainstBaseURL: false)
         XCTAssertNotNil(components)
         XCTAssertNotNil(components?.query)
-        XCTAssert(components!.query! == "filter=eq(test, hello):eq(other, thing)")
+        XCTAssert(components!.query! == "filter=eq(test,hello):eq(other,thing)")
     }
 
     func testRequestHandlesLimit() {
@@ -303,7 +303,7 @@ class MoltinTests: XCTestCase {
         let components = URLComponents(url: urlRequest!.url!, resolvingAgainstBaseURL: false)
         XCTAssertNotNil(components)
         XCTAssertNotNil(components?.query)
-        XCTAssert(components!.query! == "include=files,categories&sort=key&page[limit]=1&page[offset]=2&filter=eq(test, one)")
+        XCTAssert(components!.query! == "include=files,categories&sort=key&page[limit]=1&page[offset]=2&filter=eq(test,one)")
     }
 
     func testRequestHandlesNoData() {
@@ -416,7 +416,7 @@ class MoltinTests: XCTestCase {
         let components = URLComponents(url: urlRequest!.url!, resolvingAgainstBaseURL: false)
         XCTAssertNotNil(components)
         XCTAssertNotNil(components?.query)
-        XCTAssert(components!.query! == "include=files,categories&sort=key&page[limit]=1&page[offset]=2&filter=eq(test, one)")
+        XCTAssert(components!.query! == "include=files,categories&sort=key&page[limit]=1&page[offset]=2&filter=eq(test,one)")
 
         request = moltin.product.limit(5).offset(8)
         let secondUrlRequest = try? request.http.buildURLRequest(


### PR DESCRIPTION
## Status
* ✅ Ready
## Type
 ### Fix
  Fixes a bug
## Description
Fixes an issue where a URL encoded space character may be placed in a query parameter for filtering. 
