### PR TITLE
Removed no longer necessary codable inits

### DIFF
--- a/Sources/SDK/Models/Address.swift
+++ b/Sources/SDK/Models/Address.swift
@@ -61,11 +61,6 @@ open class Address: Codable {
         self.lastName = lastName
     }
 
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
-    }
-
     func toDictionary() -> [String: Any] {
         var data: [String: Any] = [:]
 

--- a/Sources/SDK/Models/Brand.swift
+++ b/Sources/SDK/Models/Brand.swift
@@ -47,11 +47,6 @@ open class Brand: Codable, HasRelationship {
 
         try self.decodeRelationships(fromRelationships: self.relationships, withIncludes: includes)
     }
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
-    }
 }
 
 extension Brand {

--- a/Sources/SDK/Models/Cart.swift
+++ b/Sources/SDK/Models/Cart.swift
@@ -15,11 +15,6 @@ public class CartMeta: Codable {
     enum CodingKeys: String, CodingKey {
         case displayPrice = "display_price"
     }
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
-    }
 }
 
 /// The display price for a `CartItem`
@@ -28,11 +23,6 @@ public struct CartItemDisplayPrice: Codable {
     public let unit: DisplayPrice
     /// The value price (based on quantity) for a cart item
     public let value: DisplayPrice
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
-    }
 }
 
 /// The display prices information for a `CartItem`
@@ -46,11 +36,6 @@ public struct CartItemDisplayPrices: Codable {
         case withTax = "with_tax"
         case withoutTax = "without_tax"
     }
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
-    }
 }
 
 /// The meta information for this `CartItem`
@@ -60,11 +45,6 @@ public class CartItemMeta: Codable {
 
     enum CodingKeys: String, CodingKey {
         case displayPrice = "display_price"
-    }
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
     }
 }
 
@@ -78,11 +58,6 @@ open class Cart: Codable {
     public let links: [String: String]?
     /// The meta information for this cart
     public let meta: CartMeta?
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
-    }
 }
 
 /// Represents a `CartItem` in Moltin
@@ -124,11 +99,6 @@ open class CartItem: Codable {
         case links
         case meta
     }
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
-    }
 }
 
 /// Represents various types of cart items
@@ -146,10 +116,5 @@ open class CustomCartItem: Codable {
 
     internal init(withSKU sku: String) {
         self.sku = sku
-    }
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
     }
 }

--- a/Sources/SDK/Models/Category.swift
+++ b/Sources/SDK/Models/Category.swift
@@ -47,11 +47,6 @@ open class Category: Codable, HasRelationship {
 
         try self.decodeRelationships(fromRelationships: self.relationships, withIncludes: includes)
     }
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
-    }
 }
 
 extension Category {

--- a/Sources/SDK/Models/Collection.swift
+++ b/Sources/SDK/Models/Collection.swift
@@ -47,11 +47,6 @@ open class Collection: Codable, HasRelationship {
 
         try self.decodeRelationships(fromRelationships: self.relationships, withIncludes: includes)
     }
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
-    }
 }
 
 extension Collection {

--- a/Sources/SDK/Models/Currency.swift
+++ b/Sources/SDK/Models/Currency.swift
@@ -11,11 +11,6 @@ import Foundation
 public class CurrencyMeta: Codable {
     /// The timestamps of this currency
     public let timestamps: Timestamps
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
-    }
 }
 
 /// Represents a `Currency` in Moltin
@@ -59,10 +54,5 @@ open class Currency: Codable {
         case enabled
         case links
         case meta
-    }
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
     }
 }

--- a/Sources/SDK/Models/Customer.swift
+++ b/Sources/SDK/Models/Customer.swift
@@ -23,11 +23,6 @@ open class Customer: Codable {
         self.name = name
     }
 
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
-    }
-
     func toDictionary() -> [String: Any] {
         var customerData: [String: Any] = [:]
         if let id = self.id {

--- a/Sources/SDK/Models/File.swift
+++ b/Sources/SDK/Models/File.swift
@@ -13,11 +13,6 @@ public struct FileDimensions: Codable {
     public let width: Float
     /// The height of the file
     public let height: Float
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
-    }
 }
 
 /// The meta information for a `File`
@@ -26,11 +21,6 @@ public class FileMeta: Codable {
     public let dimensions: FileDimensions
     /// The timsestamps for a `File`
     public let timestamps: Timestamps
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
-    }
 }
 
 /// Represents a `File` in Moltin
@@ -64,10 +54,5 @@ open class File: Codable {
         case link
         case links
         case meta
-    }
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
     }
 }

--- a/Sources/SDK/Models/Flow.swift
+++ b/Sources/SDK/Models/Flow.swift
@@ -13,22 +13,12 @@ open class Entry: Codable {
     public let id: String
     /// The type of this object
     public let type: String
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
-    }
 }
 
 /// Represents the meta information for a `Field`
 public struct FieldMeta: Codable {
     /// The timestamps for this `Field`
     public let timestamps: Timestamps
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
-    }
 }
 
 /// Represents a `Field` in Moltin
@@ -72,11 +62,6 @@ open class Field: Codable {
         case relationships
         case meta
     }
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
-    }
 }
 
 /// Represents a `Flow` in Moltin
@@ -93,9 +78,4 @@ open class Flow: Codable {
     public let description: String
     /// Whether this flow is enabled or not
     public let enabled: Bool
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
-    }
 }

--- a/Sources/SDK/Models/Order.swift
+++ b/Sources/SDK/Models/Order.swift
@@ -18,11 +18,6 @@ public class OrderMeta: Codable {
         case displayPrice = "display_price"
         case timestamps
     }
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
-    }
 }
 
 /// Represents the relationships for an `Order`
@@ -31,11 +26,6 @@ public class OrderRelationships: Codable {
     public let items: [String: [[String: String]]]?
     /// The customer information in this order
     public let customer: [String: [String: String]]?
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
-    }
 }
 
 /// Represents a `Order` in Moltin
@@ -76,17 +66,9 @@ open class Order: Codable {
         case meta
         case relationships
     }
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
-    }
 }
 
 /// Denotes a successful order returned from the payment gateway
 open class OrderSuccess: Codable {
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
-    }
+
 }

--- a/Sources/SDK/Models/Prices.swift
+++ b/Sources/SDK/Models/Prices.swift
@@ -15,11 +15,6 @@ public struct DisplayPrice: Codable {
     public let currency: String
     /// The formatted display price
     public let formatted: String
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
-    }
 }
 
 /// Represents display prices in Moltin with and without tax
@@ -32,10 +27,5 @@ public struct DisplayPrices: Codable {
     enum CodingKeys: String, CodingKey {
         case withTax = "with_tax"
         case withoutTax = "without_tax"
-    }
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
     }
 }

--- a/Sources/SDK/Models/Product.swift
+++ b/Sources/SDK/Models/Product.swift
@@ -22,11 +22,6 @@ public struct ProductPrice: Codable {
         case amount
         case currency
     }
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
-    }
 }
 
 /// Represents stock levels on a `Product`
@@ -35,11 +30,6 @@ public struct ProductStock: Codable {
     public let level: Int
     /// in-stock / out-stock
     public let availability: String
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
-    }
 }
 
 /// Represents variation options on a `Product`
@@ -50,11 +40,6 @@ public class ProductVariationOption: Codable {
     public let name: String
     /// The description of this option
     public let description: String
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
-    }
 }
 
 /// Represents variations on a `Product`
@@ -63,11 +48,6 @@ public class ProductVariation: Codable {
     public let id: String
     /// The options this variation has
     public let options: [ProductVariationOption]
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
-    }
 }
 
 /// Represents the meta properties of a `Product`
@@ -90,11 +70,6 @@ public class ProductMeta: Codable {
         case timestamps
         case stock
         case variations
-    }
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
     }
 }
 
@@ -172,11 +147,6 @@ open class Product: Codable, HasRelationship {
 
         try self.decodeRelationships(fromRelationships: self.relationships, withIncludes: includes)
 
-    }
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
     }
 }
 

--- a/Sources/SDK/Models/Relationship.swift
+++ b/Sources/SDK/Models/Relationship.swift
@@ -31,11 +31,6 @@ public class RelationshipMany: Codable {
     public func getIds() -> [String]? {
         return self.data?.map { $0.id }
     }
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
-    }
 }
 
 /// Represents a relationship which can hold a single item
@@ -55,11 +50,6 @@ public class RelationshipSingle: Codable {
     public func getId() -> String? {
         return self.data?.id
     }
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
-    }
 }
 
 /// Represents a relationship item
@@ -68,11 +58,6 @@ public struct RelationshipData: Codable {
     public let type: String
     /// The id of this relationship
     public let id: String
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
-    }
 }
 
 /// Represents all possible relationships a resource can have within Moltin
@@ -110,10 +95,5 @@ open class Relationships: Codable {
         case items
         case customer
         case products
-    }
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
     }
 }

--- a/Sources/SDK/Models/Timestamps.swift
+++ b/Sources/SDK/Models/Timestamps.swift
@@ -18,9 +18,4 @@ open class Timestamps: Codable {
         case createdAt = "created_at"
         case updatedAt = "updated_at"
     }
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
-    }
 }

--- a/Sources/SDK/Requests/MoltinAuth.swift
+++ b/Sources/SDK/Requests/MoltinAuth.swift
@@ -17,11 +17,6 @@ struct MoltinAuthCredentials: Codable {
         self.token = token
         self.expires = expires
     }
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
-    }
 }
 
 class MoltinAuth {

--- a/Sources/SDK/Utils/Pagination.swift
+++ b/Sources/SDK/Utils/Pagination.swift
@@ -18,11 +18,6 @@ open class PaginatedResponse<T: Codable>: Codable {
     public var links: [String: String?]?
     /// The meta information for this response
     public var meta: PaginationMeta?
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
-    }
 }
 
 /// `PaginationMeta` gives information about the pagination details to the user, such as result information and page information
@@ -31,9 +26,4 @@ open class PaginationMeta: Codable {
     public let results: [String: Int]?
     /// The page information for this response
     public let page: [String: Int]?
-
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
-    }
 }

--- a/Tests/moltin iOS Tests/RequestTests.swift
+++ b/Tests/moltin iOS Tests/RequestTests.swift
@@ -15,11 +15,6 @@ class Author: Codable, Equatable {
     static func ==(lhs: Author, rhs: Author) -> Bool {
         return lhs.name == rhs.name
     }
-    
-    @available(*, deprecated, message: "Do not use.")
-    init() {
-        fatalError("Swift 4.1 broke Codable synthesized inits")
-    }
 }
 
 


### PR DESCRIPTION
## Status
* ✅ Ready
## Type
### Refactor
  A code change that neither fixes a 
bug nor adds a feature 
## Description
Swift 4.1 temporarily broke initialisers for Codable objects. For this, we had to add a deprecated init which satisfied the compilers requirements. This is now no longer needed so these init functions can go.