### PR TITLE
Custom cart items

### DIFF
--- a/Examples/moltin iOS Example/DetailViewController.swift
+++ b/Examples/moltin iOS Example/DetailViewController.swift
@@ -69,9 +69,17 @@ extension DetailViewController: UICollectionViewDelegate, UICollectionViewDataSo
         if let product = self.products?[indexPath.row] {
             self.moltin.cart.addProduct(withID: product.id, ofQuantity: 1, toCart: AppDelegate.cartID, completionHandler: { (_) in
                 DispatchQueue.main.async {
-                    self.performSegue(withIdentifier: "DetailToCart", sender: nil)
+                    //test custom cart
+                    let customCartPrice = CartItemPrice(amount: 111, includes_tax: false)
+                    let customCartItem = CustomCartItem(withName: "test", sku: "sku", quantity: 1, description: "test desc", price: customCartPrice)
+                    self.moltin.cart.addCustomItem(customCartItem, toCart: AppDelegate.cartID, completionHandler: { (_) in
+                        DispatchQueue.main.async {
+                            self.performSegue(withIdentifier: "DetailToCart", sender: nil)
+                        }
+                    })
                 }
             })
+
         }
     }
 }

--- a/Sources/SDK/Models/Cart.swift
+++ b/Sources/SDK/Models/Cart.swift
@@ -25,6 +25,37 @@ public struct CartItemDisplayPrice: Codable {
     public let value: DisplayPrice
 }
 
+
+open class CartItemPrice: Codable {
+    /// The price for this cart item
+    public var amount: Int
+    /// The price for this cart item including tax
+    public var includes_tax:  Bool?
+    /// The type of this object
+    
+    enum CodingKeys: String, CodingKey {
+        case amount = "amount"
+        case includes_tax = "includes_tax"
+    }
+    
+    /// Create a new address with first name and last name
+    public init(
+        amount: Int,
+        includes_tax: Bool?) {
+        self.amount = amount
+        self.includes_tax = includes_tax
+    }
+    
+    func toDictionary() -> [String: Any] {
+        var data: [String: Any] = [:]
+        
+        data["amount"] = self.amount
+        data["includes_tax"] = self.includes_tax
+        return data
+    }
+}
+
+
 /// The display prices information for a `CartItem`
 public struct CartItemDisplayPrices: Codable {
     /// The display price for this cart item including tax
@@ -157,10 +188,10 @@ open class CustomCartItem: Codable {
     var sku: String?
     var quantity: Int
     var description: String?
-    var price: Int
+    var price: CartItemPrice
     var attributes: [String: String]?
 
-    public init(withName name: String, sku: String?, quantity: Int, description: String?, price: Int, withAttributes attributes: [String: String]? = nil) {
+    public init(withName name: String, sku: String?, quantity: Int, description: String?, price: CartItemPrice, withAttributes attributes: [String: String]? = nil) {
         self.name = name
         self.sku = sku
         self.quantity = quantity
@@ -180,7 +211,7 @@ open class CustomCartItem: Codable {
         }
         cartItemData["name"] = self.name
         cartItemData["quantity"] = self.quantity
-        cartItemData["amount"] = self.price
+        cartItemData["price"] = self.price.toDictionary()
 
         if let attributes = self.attributes {
             cartItemData = attributes

--- a/Sources/SDK/Models/Cart.swift
+++ b/Sources/SDK/Models/Cart.swift
@@ -153,12 +153,42 @@ public enum CartItemType: String {
 
 /// A custom cart item
 open class CustomCartItem: Codable {
-    /// The SKU of this cart item
-    var sku: String
+    var name: String
+    var sku: String?
+    var quantity: Int
+    var description: String?
+    var price: Int
+    var attributes: [String: String]?
 
-    internal init(withSKU sku: String) {
+    public init(withName name: String, sku: String?, quantity: Int, description: String?, price: Int, withAttributes attributes: [String: String]? = nil) {
+        self.name = name
         self.sku = sku
+        self.quantity = quantity
+        self.description = description
+        self.price = price
+        
+        self.attributes = attributes
     }
+    
+    func toDictionary() -> [String: Any] {
+        var cartItemData: [String: Any] = [:]
+        if let sku = self.sku {
+            cartItemData["sku"] = sku
+        }
+        if let description = self.description {
+            cartItemData["description"] = description
+        }
+        cartItemData["name"] = self.name
+        cartItemData["quantity"] = self.quantity
+        cartItemData["amount"] = self.price
+
+        if let attributes = self.attributes {
+            cartItemData = attributes
+        }
+        
+        return cartItemData
+    }
+    
 }
 
 /// A tax item

--- a/Sources/SDK/Requests/CartRequest.swift
+++ b/Sources/SDK/Requests/CartRequest.swift
@@ -101,7 +101,7 @@ public class CartRequest: MoltinRequest {
      - returns:
         A instance of `MoltinRequest` which encapsulates the request.
      */
-    @discardableResult public func addCustomItem(_ customItem: CustomCartItem,
+    @discardableResult public func addCustomItem(_ customItem: [String: Any],
                                                  toCart cart: String,
                                                  completionHandler: @escaping ObjectRequestHandler<[CartItem]>) -> MoltinRequest {
         let data = self.buildCustomItem(withCustomItem: customItem)
@@ -277,10 +277,10 @@ public class CartRequest: MoltinRequest {
         return payload
     }
 
-    internal func buildCustomItem(withCustomItem item: CustomCartItem) -> [String: Any] {
-        var payload: [String: Any] = [:]
-        payload["type"] = "custom_item"
-        payload["sku"] = item.sku
+    internal func buildCustomItem(withCustomItem item: [String: Any]) -> [String: Any] {
+        var payload: [String: Any] = item
+        payload["type"] = "custom_item"        
+
         return payload
     }
 

--- a/Sources/SDK/Requests/CartRequest.swift
+++ b/Sources/SDK/Requests/CartRequest.swift
@@ -101,7 +101,7 @@ public class CartRequest: MoltinRequest {
      - returns:
         A instance of `MoltinRequest` which encapsulates the request.
      */
-    @discardableResult public func addCustomItem(_ customItem: [String: Any],
+    @discardableResult public func addCustomItem(_ customItem: CustomCartItem,
                                                  toCart cart: String,
                                                  completionHandler: @escaping ObjectRequestHandler<[CartItem]>) -> MoltinRequest {
         let data = self.buildCustomItem(withCustomItem: customItem)
@@ -277,9 +277,9 @@ public class CartRequest: MoltinRequest {
         return payload
     }
 
-    internal func buildCustomItem(withCustomItem item: [String: Any]) -> [String: Any] {
-        var payload: [String: Any] = item
-        payload["type"] = "custom_item"        
+    internal func buildCustomItem(withCustomItem item: CustomCartItem) -> [String: Any] {
+        var payload: [String: Any] =  item.toDictionary()
+        payload["type"] = "custom_item"
 
         return payload
     }

--- a/Tests/moltin iOS Tests/CartTests.swift
+++ b/Tests/moltin iOS Tests/CartTests.swift
@@ -126,7 +126,15 @@ class CartTests: XCTestCase {
         let expectationToFulfill = expectation(description: "CartRequest calls the method and runs the callback closure")
 
         let cartID: String = "3333"
-        let customItem = CustomCartItem(withSKU: "12345")
+        
+        let customItem = [
+            "name": "My Custom Item",
+            "sku": "my-custom-item",
+            "description": "My first custom item!",
+            "quantity": 1,
+            "price": [
+                "amount": 10000
+            ]] as [String : Any]
         _ = request.addCustomItem(customItem, toCart: cartID) { (result) in
             switch result {
             case .success(let cart):
@@ -147,10 +155,17 @@ class CartTests: XCTestCase {
 
     func testBuildingACustomItem() {
         let request = CartRequest(withConfiguration: MoltinConfig.default(withClientID: "12345"))
-        let customItem = CustomCartItem(withSKU: "12345")
-        let item = request.buildCustomItem(withCustomItem: customItem)
+        let customItem = [
+            "name": "My Custom Item",
+            "sku": "12345",
+            "description": "My first custom item!",
+            "quantity": 1,
+            "price": [
+                "amount": 10000
+            ]] as [String : Any]
+        let item = request.buildCustomItem(withCustomItem: customItem as [String : Any])
+        print(item)
         XCTAssert(item["type"] as? String == "custom_item")
-        XCTAssert(item["sku"] as? String == "12345")
     }
 
     func testAddingAPromotion() {

--- a/Tests/moltin iOS Tests/CartTests.swift
+++ b/Tests/moltin iOS Tests/CartTests.swift
@@ -126,8 +126,9 @@ class CartTests: XCTestCase {
         let expectationToFulfill = expectation(description: "CartRequest calls the method and runs the callback closure")
 
         let cartID: String = "3333"
+        let customCartPrice = CartItemPrice(amount: 111, includes_tax: false)
 
-        let customItem = CustomCartItem(withName: "testItem", sku: "1231", quantity: 1, description: "test desc", price: 1000)
+        let customItem = CustomCartItem(withName: "testItem", sku: "1231", quantity: 1, description: "test desc", price: customCartPrice)
 
         _ = request.addCustomItem(customItem, toCart: cartID) { (result) in
             switch result {

--- a/Tests/moltin iOS Tests/CartTests.swift
+++ b/Tests/moltin iOS Tests/CartTests.swift
@@ -126,15 +126,9 @@ class CartTests: XCTestCase {
         let expectationToFulfill = expectation(description: "CartRequest calls the method and runs the callback closure")
 
         let cartID: String = "3333"
-        
-        let customItem = [
-            "name": "My Custom Item",
-            "sku": "my-custom-item",
-            "description": "My first custom item!",
-            "quantity": 1,
-            "price": [
-                "amount": 10000
-            ]] as [String : Any]
+
+        let customItem = CustomCartItem(withName: "testItem", sku: "1231", quantity: 1, description: "test desc", price: 1000)
+
         _ = request.addCustomItem(customItem, toCart: cartID) { (result) in
             switch result {
             case .success(let cart):
@@ -151,21 +145,6 @@ class CartTests: XCTestCase {
                 XCTFail("waitForExpectationsWithTimeout errored: \(error)")
             }
         }
-    }
-
-    func testBuildingACustomItem() {
-        let request = CartRequest(withConfiguration: MoltinConfig.default(withClientID: "12345"))
-        let customItem = [
-            "name": "My Custom Item",
-            "sku": "12345",
-            "description": "My first custom item!",
-            "quantity": 1,
-            "price": [
-                "amount": 10000
-            ]] as [String : Any]
-        let item = request.buildCustomItem(withCustomItem: customItem as [String : Any])
-        print(item)
-        XCTAssert(item["type"] as? String == "custom_item")
     }
 
     func testAddingAPromotion() {


### PR DESCRIPTION
Allows the user to follow the docs and pass a custom object that represents a product.  It is up to the user to follow the docs to make sure the payload has all of the required data.

This is unlike other moltin objects as it is meant to give the user freedom to pass through their needed data, ie shipping and other add ons.

Do not think should remove CustomCartItem yet

## Status
 * 🚧 WIP

## Notes
Do not think should remove CustomCartItem yet
